### PR TITLE
Fixed an issue regarding the SSO login

### DIFF
--- a/src/main/java/fr/nil/backedflow/services/AuthenticationService.java
+++ b/src/main/java/fr/nil/backedflow/services/AuthenticationService.java
@@ -29,8 +29,9 @@
     import java.util.HashMap;
     import java.util.Map;
     import java.util.Objects;
+    import java.util.UUID;
 
-@Service
+    @Service
 @RequiredArgsConstructor
 @Slf4j
 public class AuthenticationService {
@@ -152,6 +153,7 @@ public class AuthenticationService {
         }
 
         User user = User.builder()
+                .id(UUID.randomUUID())
                 .firstName(request.getFirstName())
                 .lastName(request.getLastName())
                 .mail(request.getEmail())


### PR DESCRIPTION
As an answer to #48 fixed the issue that when a user logged in using a Google account the userID was null and not add to the claims in the JWT Token